### PR TITLE
Restore french translations

### DIFF
--- a/ModernFlyouts/MultilingualResources/ModernFlyouts.fr.xlf
+++ b/ModernFlyouts/MultilingualResources/ModernFlyouts.fr.xlf
@@ -8,432 +8,420 @@
       <group id="MODERNFLYOUTS/PROPERTIES/STRINGS.RESX" datatype="resx">
         <trans-unit id="About" translate="yes" xml:space="preserve">
           <source>About</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">À propos</target>
+          <target state="translated">À propos</target>
+        </trans-unit>
+        <trans-unit id="About.AppDescription" translate="yes" xml:space="preserve">
+          <source>This app is designed to be a modern Fluent Design replacement for the old metro themed flyouts present in Windows since Windows 8.</source>
+          <target state="translated">Cette application est conçue pour être un remplacement moderne en Fluent Design pour les anciens menus volants de type Metro présents dans Windows depuis Windows 8.</target>
+        </trans-unit>
+        <trans-unit id="About.Contributors" translate="yes" xml:space="preserve">
+          <source>Contributors</source>
+          <target state="translated">Contributeurs</target>
+        </trans-unit>
+        <trans-unit id="About.Dependencies" translate="yes" xml:space="preserve">
+          <source>Dependencies</source>
+          <target state="translated">Dépendances</target>
+        </trans-unit>
+        <trans-unit id="About.FileABug" translate="yes" xml:space="preserve">
+          <source>If you find any bugs, please open a new issue in the github repository.</source>
+          <target state="translated">Si vous trouvez des bogues, veuillez ouvrir un nouveau ticket dans le dépôt GitHub.</target>
+        </trans-unit>
+        <trans-unit id="About.GitHub" translate="yes" xml:space="preserve">
+          <source>GitHub repository</source>
+          <target state="translated">Dépôt GitHub</target>
+        </trans-unit>
+        <trans-unit id="About.OpenNewIssue" translate="yes" xml:space="preserve">
+          <source>Open a new issue</source>
+          <target state="translated">Ouvrir un nouveau ticket</target>
+        </trans-unit>
+        <trans-unit id="About.RateAndReview" translate="yes" xml:space="preserve">
+          <source>Rate and Review on Microsoft Store</source>
+          <target state="translated">Notez et passez en revue sur le Microsoft Store</target>
+        </trans-unit>
+        <trans-unit id="About.Version" translate="yes" xml:space="preserve">
+          <source>Version : </source>
+          <target state="translated">Version : </target>
         </trans-unit>
         <trans-unit id="AirplaneMode.NotAvailable" translate="yes" xml:space="preserve">
           <source>Airplane mode is not available :(</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Le Mode Avion n’est pas disponible :(</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">Le Mode Avion n’est pas disponible :(</target>
         </trans-unit>
         <trans-unit id="AirplaneModeOff" translate="yes" xml:space="preserve">
           <source>Airplane mode off</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Mode Avion désactivé</target>
+          <target state="translated">Mode Avion désactivé</target>
         </trans-unit>
         <trans-unit id="AirplaneModeOn" translate="yes" xml:space="preserve">
           <source>Airplane mode on</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Mode Avion activé</target>
+          <target state="translated">Mode Avion activé</target>
         </trans-unit>
         <trans-unit id="Align" translate="yes" xml:space="preserve">
           <source>Align to default position</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Aligner sur la position par défaut</target>
+          <target state="translated">Aligner sur la position par défaut</target>
+        </trans-unit>
+        <trans-unit id="AudioFlyoutHelper.MaxVerticalSessionControlsCount" translate="yes" xml:space="preserve">
+          <source>Number of sessions to show</source>
+          <target state="translated">Nombre de sessions à afficher</target>
         </trans-unit>
         <trans-unit id="AudioFlyoutHelper.NoDevices" translate="yes" xml:space="preserve">
           <source>No Connected Audio Devices</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Aucun périphérique audio connecté</target>
+          <target state="translated">Aucun périphérique audio connecté</target>
+        </trans-unit>
+        <trans-unit id="AudioFlyoutHelper.SessionsPanelOrientation" translate="yes" xml:space="preserve">
+          <source>Media sessions panel orientation</source>
+          <target state="translated">Orientation du panneau des sessions médias</target>
+        </trans-unit>
+        <trans-unit id="AudioFlyoutHelper.ShowGSMTCInVolumeFlyout" translate="yes" xml:space="preserve">
+          <source>Show Global System Media Transport Controls (GSMTC) aka Media controls in Volume flyout</source>
+          <target state="translated">Afficher les contrôles de transport global des médias systèmes (GSMTC) alias les contrôles médias, dans le menu volant Volume</target>
+        </trans-unit>
+        <trans-unit id="AudioFlyoutHelper.ShowVolumeControlInGSMTCFlyout" translate="yes" xml:space="preserve">
+          <source>Show Volume control in Global System Media Transport Controls (GSMTC) aka Media flyout</source>
+          <target state="translated">Afficher le contrôle Volume dans le menu volant des contrôles de transport global des médias systèmes (GSMTC) alias le menu volant des médias</target>
+        </trans-unit>
+        <trans-unit id="AudioFlyoutHelper.ThumbnailAlignment" translate="yes" xml:space="preserve">
+          <source>Thumbnail alignment</source>
+          <target state="translated">Alignement de la miniature</target>
         </trans-unit>
         <trans-unit id="Close" translate="yes" xml:space="preserve">
           <source>Close</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Fermer</target>
+          <target state="translated">Fermer</target>
+        </trans-unit>
+        <trans-unit id="Enums.DefaultFlyout.ModernFlyouts" translate="yes" xml:space="preserve">
+          <source>ModernFlyouts</source>
+          <target state="translated">ModernFlyouts</target>
+        </trans-unit>
+        <trans-unit id="Enums.DefaultFlyout.None" translate="yes" xml:space="preserve">
+          <source>None</source>
+          <target state="translated">Aucun</target>
+        </trans-unit>
+        <trans-unit id="Enums.DefaultFlyout.WindowsDefault" translate="yes" xml:space="preserve">
+          <source>Windows default</source>
+          <target state="translated">Windows par défaut</target>
+        </trans-unit>
+        <trans-unit id="Enums.ElementTheme.Dark" translate="yes" xml:space="preserve">
+          <source>Dark</source>
+          <target state="translated">Sombre</target>
+        </trans-unit>
+        <trans-unit id="Enums.ElementTheme.Light" translate="yes" xml:space="preserve">
+          <source>Light</source>
+          <target state="translated">Clair</target>
+        </trans-unit>
+        <trans-unit id="Enums.Orientation.Horizontal" translate="yes" xml:space="preserve">
+          <source>Horizontal</source>
+          <target state="translated">Horizontale</target>
+        </trans-unit>
+        <trans-unit id="Enums.Orientation.Vertical" translate="yes" xml:space="preserve">
+          <source>Vertical</source>
+          <target state="translated">Verticale</target>
+        </trans-unit>
+        <trans-unit id="Enums.TopBarVisibility.AutoHide" translate="yes" xml:space="preserve">
+          <source>Auto-hide</source>
+          <target state="translated">Masquer automatiquement</target>
+        </trans-unit>
+        <trans-unit id="Enums.TopBarVisibility.Collapsed" translate="yes" xml:space="preserve">
+          <source>Collapsed</source>
+          <target state="translated">Réduite</target>
+        </trans-unit>
+        <trans-unit id="Enums.TopBarVisibility.Visible" translate="yes" xml:space="preserve">
+          <source>Visible</source>
+          <target state="translated">Visible</target>
         </trans-unit>
         <trans-unit id="ExitItem" translate="yes" xml:space="preserve">
           <source>Exit</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Quitter</target>
+          <target state="translated">Quitter</target>
         </trans-unit>
         <trans-unit id="ExitItemDescription" translate="yes" xml:space="preserve">
           <source>Exit the app safely</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Quitter l’application en toute sécurité</target>
+          <target state="translated">Quitter l’application en toute sécurité</target>
         </trans-unit>
         <trans-unit id="GeneralSettings" translate="yes" xml:space="preserve">
           <source>General</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Général</target>
+          <target state="translated">Général</target>
+        </trans-unit>
+        <trans-unit id="LockKeysFlyoutHelper.CapsLock" translate="yes" xml:space="preserve">
+          <source>Caps lock</source>
+          <target state="translated">Verr Maj</target>
+        </trans-unit>
+        <trans-unit id="LockKeysFlyoutHelper.Insert" translate="yes" xml:space="preserve">
+          <source>Insert</source>
+          <target state="translated">Insérer</target>
         </trans-unit>
         <trans-unit id="LockKeysFlyoutHelper.InsertMode" translate="yes" xml:space="preserve">
           <source>Insert Mode</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Mode insertion</target>
+          <target state="translated">Mode Insertion</target>
         </trans-unit>
         <trans-unit id="LockKeysFlyoutHelper.KeyIsOff" translate="yes" xml:space="preserve">
           <source>{0} is off</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">{0} est désactivé</target>
+          <target state="translated">{0} est désactivé</target>
           <note from="MultilingualBuild" annotates="source" priority="2">E.g. Caps lock is off</note>
         </trans-unit>
         <trans-unit id="LockKeysFlyoutHelper.KeyIsOn" translate="yes" xml:space="preserve">
           <source>{0} is on</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">{0} est activé</target>
+          <target state="translated">{0} est activé</target>
           <note from="MultilingualBuild" annotates="source" priority="2">E.g. Caps lock is on</note>
+        </trans-unit>
+        <trans-unit id="LockKeysFlyoutHelper.NumLock" translate="yes" xml:space="preserve">
+          <source>Num lock</source>
+          <target state="translated">Verr Num</target>
         </trans-unit>
         <trans-unit id="LockKeysFlyoutHelper.OvertypeMode" translate="yes" xml:space="preserve">
           <source>Overtype Mode</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Mode refrappe</target>
+          <target state="translated">Mode Refrappe</target>
+        </trans-unit>
+        <trans-unit id="LockKeysFlyoutHelper.ScrollLock" translate="yes" xml:space="preserve">
+          <source>Scroll lock</source>
+          <target state="translated">Verr Défil</target>
+        </trans-unit>
+        <trans-unit id="LockKeysFlyoutHelper.SelectKeyDescription" translate="yes" xml:space="preserve">
+          <source>Select the keys you want to show the flyout for</source>
+          <target state="translated">Selectionnez les touches dont vous voulez un menu volant</target>
         </trans-unit>
         <trans-unit id="PinTopBar" translate="yes" xml:space="preserve">
           <source>Pin TopBar</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Épingler la barre supérieure</target>
+          <target state="translated">Épingler la barre supérieure</target>
         </trans-unit>
         <trans-unit id="PointValidationRule.PointFormatInvalidMessage" translate="yes" xml:space="preserve">
           <source>Please enter the point in the format 'X,Y' (for e.g. 50,60).</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Veuillez entrer le point dans le format 'X,Y' (par exemple 50,60).</target>
+          <target state="translated">Veuillez entrer le point dans le format 'X,Y' (par exemple 50,60).</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Error message shown when there are problem parsing a string value into a Point</note>
         </trans-unit>
         <trans-unit id="PointValidationRule.PointOutOfRangeMessage" translate="yes" xml:space="preserve">
           <source>Please enter X,Y values in the range {0} - {1}.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Veuillez entrer des valeurs X,Y dans la plage {0} - {1}.</target>
+          <target state="translated">Veuillez entrer des valeurs X,Y dans la plage {0} - {1}.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Error message shown when a point's X or Y values goes out of int32 range</note>
         </trans-unit>
         <trans-unit id="PointValidationRule.StringConvertionErrorMessage" translate="yes" xml:space="preserve">
           <source>Value cannot be coverted to string.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">La valeur ne peut pas être convertie en une chaîne de caractères.</target>
+          <target state="translated">La valeur ne peut pas être convertie en une chaîne de caractères.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Error message shown when there is problem in converting an object into a string</note>
         </trans-unit>
         <trans-unit id="RestoreDefaultItem" translate="yes" xml:space="preserve">
           <source>Restore legacy flyout</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Restaurer les paramètres par défaut</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">Restaurer l'ancien menu volant</target>
         </trans-unit>
         <trans-unit id="RestoreDefaultItemDescription" translate="yes" xml:space="preserve">
           <source>Restores the windows default flyout and safely quits this app</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Restaure le menu volant par défaut windows et quitte en toute sécurité cette application</target>
+          <target state="translated">Restaure le menu volant par défaut de Windows et quitte en toute sécurité cette application</target>
         </trans-unit>
         <trans-unit id="SessionControl.MoreControls" translate="yes" xml:space="preserve">
           <source>More Controls</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Autres contrôles</target>
+          <target state="translated">Autres contrôles</target>
         </trans-unit>
         <trans-unit id="SessionControl.Next" translate="yes" xml:space="preserve">
           <source>Next</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Suivant</target>
+          <target state="translated">Suivant</target>
         </trans-unit>
         <trans-unit id="SessionControl.Pause" translate="yes" xml:space="preserve">
           <source>Pause</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Suspendre</target>
+          <target state="translated">Suspendre</target>
         </trans-unit>
         <trans-unit id="SessionControl.Play" translate="yes" xml:space="preserve">
           <source>Play</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Lire</target>
+          <target state="translated">Lire</target>
         </trans-unit>
         <trans-unit id="SessionControl.Previous" translate="yes" xml:space="preserve">
           <source>Previous</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Précédent</target>
+          <target state="translated">Précédent</target>
         </trans-unit>
         <trans-unit id="SessionControl.RepeatAll" translate="yes" xml:space="preserve">
           <source>Repeat: all</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Répéter : tous</target>
+          <target state="translated">Répéter : tous</target>
         </trans-unit>
         <trans-unit id="SessionControl.RepeatOff" translate="yes" xml:space="preserve">
           <source>Repeat: off</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Répéter : non</target>
+          <target state="translated">Répéter : non</target>
         </trans-unit>
         <trans-unit id="SessionControl.RepeatOne" translate="yes" xml:space="preserve">
           <source>Repeat: one</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Répéter : un</target>
+          <target state="translated">Répéter : un</target>
         </trans-unit>
         <trans-unit id="SessionControl.ShuffleOff" translate="yes" xml:space="preserve">
           <source>Shuffle: off</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Mélanger : non</target>
+          <target state="translated">Mélanger : non</target>
         </trans-unit>
         <trans-unit id="SessionControl.ShuffleOn" translate="yes" xml:space="preserve">
           <source>Shuffle: on</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Mélanger : oui</target>
+          <target state="translated">Mélanger : oui</target>
         </trans-unit>
         <trans-unit id="SessionControl.Stop" translate="yes" xml:space="preserve">
           <source>Stop</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Arrêter</target>
+          <target state="translated">Arrêter</target>
         </trans-unit>
         <trans-unit id="SessionControl.TimelineInfo" translate="yes" xml:space="preserve">
           <source>Timeline Info</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Informations de la chronologie</target>
+          <target state="translated">Informations de la chronologie</target>
         </trans-unit>
         <trans-unit id="Settings.Additional" translate="yes" xml:space="preserve">
           <source>Additional</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Additionnel</target>
-        </trans-unit>
-        <trans-unit id="Settings.Behavior" translate="yes" xml:space="preserve">
-          <source>Behavior</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Comportement</target>
-        </trans-unit>
-        <trans-unit id="Settings.DefaultFlyout" translate="yes" xml:space="preserve">
-          <source>Default Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Menu volant par défaut</target>
-        </trans-unit>
-        <trans-unit id="Settings.DefaultFlyoutDescription" translate="yes" xml:space="preserve">
-          <source>Select the default flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Sélectionner le menu volant par défaut</target>
-        </trans-unit>
-        <trans-unit id="Settings.DefaultFlyoutWarningMessage" translate="yes" xml:space="preserve">
-          <source>Choosing the Windows Default Flyout as default won't close this app. This app will still keep running in the background. Please exit this app safely to improve performance.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Choisir le menu volant par défaut Windows comme menu par défaut ne fermera pas cette application. Cette application continuera à fonctionner en arrière-plan. Veuillez quitter cette application en toute sécurité pour améliorer les performances.</target>
-        </trans-unit>
-        <trans-unit id="Settings.Disabled" translate="yes" xml:space="preserve">
-          <source>Disabled</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Désactivé</target>
-        </trans-unit>
-        <trans-unit id="Settings.Enabled" translate="yes" xml:space="preserve">
-          <source>Enabled</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Activé</target>
-        </trans-unit>
-        <trans-unit id="Settings.FlyoutBackgroundOpacity" translate="yes" xml:space="preserve">
-          <source>Flyout background opacity</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Opacité d’arrière-plan du menu volant</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.FlyoutDefaultPosition" translate="yes" xml:space="preserve">
-          <source>Flyout default position</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Position par défaut du menu volant (pour le bouton Aligner)</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.FlyoutDefaultPositionDescription" translate="yes" xml:space="preserve">
-          <source>Type the position in 'X,Y' format (for e.g. 50,60)</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Entrez la position au format 'X,Y' (par exemple 50,60)</target>
-        </trans-unit>
-        <trans-unit id="Settings.FlyoutTopBar" translate="yes" xml:space="preserve">
-          <source>Flyout TopBar</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Barre supérieure du menu volant</target>
-        </trans-unit>
-        <trans-unit id="Settings.Modules" translate="yes" xml:space="preserve">
-          <source>Flyout Modules</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Modules</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.Modules.Airplane" translate="yes" xml:space="preserve">
-          <source>Airplane mode</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Module menu volant Mode Avion</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.Modules.Audio" translate="yes" xml:space="preserve">
-          <source>Audio</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Module menu volant Audio</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.Modules.Brightness" translate="yes" xml:space="preserve">
-          <source>Brightness</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Module menu volant Luminosité</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.Modules.LockKeys" translate="yes" xml:space="preserve">
-          <source>Lock keys</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Module menu volant Touches de verrouillage</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.RunAtStartup" translate="yes" xml:space="preserve">
-          <source>Run at startup</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Lancer au démarrage</target>
-        </trans-unit>
-        <trans-unit id="SettingsItem" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Paramètres</target>
-        </trans-unit>
-        <trans-unit id="SettingsItemDescription" translate="yes" xml:space="preserve">
-          <source>Open settings window</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Ouvrir la fenêtre des paramètres</target>
-        </trans-unit>
-        <trans-unit id="UnpinTopBar" translate="yes" xml:space="preserve">
-          <source>Unpin TopBar</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Désépingler la barre supérieure</target>
-        </trans-unit>
-        <trans-unit id="Enums.DefaultFlyout.ModernFlyouts" translate="yes" xml:space="preserve">
-          <source>ModernFlyouts</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">ModernFlyouts</target>
-        </trans-unit>
-        <trans-unit id="Enums.DefaultFlyout.None" translate="yes" xml:space="preserve">
-          <source>None</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Aucun</target>
-        </trans-unit>
-        <trans-unit id="Enums.DefaultFlyout.WindowsDefault" translate="yes" xml:space="preserve">
-          <source>Windows default</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Windows par défaut</target>
-        </trans-unit>
-        <trans-unit id="Enums.Orientation.Horizontal" translate="yes" xml:space="preserve">
-          <source>Horizontal</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Horizontalement</target>
-        </trans-unit>
-        <trans-unit id="Enums.Orientation.Vertical" translate="yes" xml:space="preserve">
-          <source>Vertical</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Verticale</target>
-        </trans-unit>
-        <trans-unit id="About.AppDescription" translate="yes" xml:space="preserve">
-          <source>This app is designed to be a modern Fluent Design replacement for the old metro themed flyouts present in Windows since Windows 8.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Cette application est conçue pour être un remplacement moderne fluent design pour les anciens flyouts sur le thème du métro présents dans Windows depuis Windows 8.</target>
-        </trans-unit>
-        <trans-unit id="About.Contributors" translate="yes" xml:space="preserve">
-          <source>Contributors</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Collaborateurs</target>
-        </trans-unit>
-        <trans-unit id="About.GitHub" translate="yes" xml:space="preserve">
-          <source>GitHub repository</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dépôt GitHub</target>
-        </trans-unit>
-        <trans-unit id="About.OpenNewIssue" translate="yes" xml:space="preserve">
-          <source>Open a new issue</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Ouvrir un nouveau numéro</target>
-        </trans-unit>
-        <trans-unit id="About.RateAndReview" translate="yes" xml:space="preserve">
-          <source>Rate and Review on Microsoft Store</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Taux et révision sur Microsoft Store</target>
-        </trans-unit>
-        <trans-unit id="About.Version" translate="yes" xml:space="preserve">
-          <source>Version : </source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Version: </target>
-        </trans-unit>
-        <trans-unit id="Settings.Language" translate="yes" xml:space="preserve">
-          <source>Language</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Langue</target>
-        </trans-unit>
-        <trans-unit id="Settings.LanguageDescription" translate="yes" xml:space="preserve">
-          <source>Restart required to apply language change properly</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">S’il vous plaît redémarrer l’application pour changer la langue correctement</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.SystemDefault" translate="yes" xml:space="preserve">
-          <source>System default</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Valeur système par défaut</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="About.Dependencies" translate="yes" xml:space="preserve">
-          <source>Dependencies</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dépendances</target>
-        </trans-unit>
-        <trans-unit id="About.FileABug" translate="yes" xml:space="preserve">
-          <source>If you find any bugs, please open a new issue in the github repository.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Si vous trouvez des bogues, ouvrez un nouveau problème dans le référentiel github.</target>
-        </trans-unit>
-        <trans-unit id="AudioFlyoutHelper.MaxVerticalSessionControlsCount" translate="yes" xml:space="preserve">
-          <source>Number of sessions to show</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Nombre de séances à afficher</target>
-        </trans-unit>
-        <trans-unit id="AudioFlyoutHelper.SessionsPanelOrientation" translate="yes" xml:space="preserve">
-          <source>Media sessions panel orientation</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Orientation du panel des sessions de médias</target>
-        </trans-unit>
-        <trans-unit id="AudioFlyoutHelper.ShowGSMTCInVolumeFlyout" translate="yes" xml:space="preserve">
-          <source>Show Global System Media Transport Controls (GSMTC) aka Media controls in Volume flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Afficher global system media transport controls (GSMTC) aka Media controls in Volume flyout</target>
-        </trans-unit>
-        <trans-unit id="AudioFlyoutHelper.ShowVolumeControlInGSMTCFlyout" translate="yes" xml:space="preserve">
-          <source>Show Volume control in Global System Media Transport Controls (GSMTC) aka Media flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Afficher le contrôle du volume dans Global System Media Transport Controls (GSMTC) aka Media flyout</target>
-        </trans-unit>
-        <trans-unit id="AudioFlyoutHelper.ThumbnailAlignment" translate="yes" xml:space="preserve">
-          <source>Thumbnail alignment</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Alignement des miniatures</target>
-        </trans-unit>
-        <trans-unit id="Enums.ElementTheme.Dark" translate="yes" xml:space="preserve">
-          <source>Dark</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Sombre</target>
-        </trans-unit>
-        <trans-unit id="Enums.ElementTheme.Light" translate="yes" xml:space="preserve">
-          <source>Light</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Clair</target>
-        </trans-unit>
-        <trans-unit id="Enums.TopBarVisibility.AutoHide" translate="yes" xml:space="preserve">
-          <source>Auto-hide</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Masquer automatiquement</target>
-        </trans-unit>
-        <trans-unit id="Enums.TopBarVisibility.Collapsed" translate="yes" xml:space="preserve">
-          <source>Collapsed</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Réduit</target>
-        </trans-unit>
-        <trans-unit id="Enums.TopBarVisibility.Visible" translate="yes" xml:space="preserve">
-          <source>Visible</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Visible</target>
-        </trans-unit>
-        <trans-unit id="LockKeysFlyoutHelper.CapsLock" translate="yes" xml:space="preserve">
-          <source>Caps lock</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Verr. maj</target>
-        </trans-unit>
-        <trans-unit id="LockKeysFlyoutHelper.Insert" translate="yes" xml:space="preserve">
-          <source>Insert</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Insérer</target>
-        </trans-unit>
-        <trans-unit id="LockKeysFlyoutHelper.NumLock" translate="yes" xml:space="preserve">
-          <source>Num lock</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Verrouillage num</target>
-        </trans-unit>
-        <trans-unit id="LockKeysFlyoutHelper.ScrollLock" translate="yes" xml:space="preserve">
-          <source>Scroll lock</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Verrouillage de défilement</target>
-        </trans-unit>
-        <trans-unit id="LockKeysFlyoutHelper.SelectKeyDescription" translate="yes" xml:space="preserve">
-          <source>Select the keys you want to show the flyout for</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Sélectionnez les touches pour lesquelle vous souhaitez afficher le menu volant</target>
+          <target state="translated">Additionnel</target>
         </trans-unit>
         <trans-unit id="Settings.Appearance" translate="yes" xml:space="preserve">
           <source>Appearance</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Apparence</target>
-        </trans-unit>
-        <trans-unit id="Settings.EnableModule.Airplane" translate="yes" xml:space="preserve">
-          <source>Enable Airplane mode Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Activer le mode Flyout</target>
-        </trans-unit>
-        <trans-unit id="Settings.EnableModule.Audio" translate="yes" xml:space="preserve">
-          <source>Enable Audio Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Activer le vol d’envol audio</target>
-        </trans-unit>
-        <trans-unit id="Settings.EnableModule.Brightness" translate="yes" xml:space="preserve">
-          <source>Enable Brightness Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Activer le flyout de luminosité</target>
-        </trans-unit>
-        <trans-unit id="Settings.EnableModule.LockKeys" translate="yes" xml:space="preserve">
-          <source>Enable Lock keys Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Activer les clés de verrouillage Flyout</target>
-        </trans-unit>
-        <trans-unit id="Settings.FlyoutTheme" translate="yes" xml:space="preserve">
-          <source>Flyout theme</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Thème Flyout</target>
-        </trans-unit>
-        <trans-unit id="Settings.FlyoutTimeout" translate="yes" xml:space="preserve">
-          <source>Flyout timeout (ms)</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Délai d’expiration de vol d’arrêt (ms)</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-        </trans-unit>
-        <trans-unit id="Settings.Left" translate="yes" xml:space="preserve">
-          <source>Left</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Gauche</target>
-        </trans-unit>
-        <trans-unit id="Settings.Modules.Audio.Media" translate="yes" xml:space="preserve">
-          <source>Media</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Média</target>
-        </trans-unit>
-        <trans-unit id="Settings.Modules.Audio.Volume" translate="yes" xml:space="preserve">
-          <source>Volume</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Année</target>
-        </trans-unit>
-        <trans-unit id="Settings.Right" translate="yes" xml:space="preserve">
-          <source>Right</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Droite</target>
-        </trans-unit>
-        <trans-unit id="Settings.TopBarVisibility" translate="yes" xml:space="preserve">
-          <source>TopBar visibility</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Visibilité TopBar</target>
-        </trans-unit>
-        <trans-unit id="Settings.TrayIconEnabled" translate="yes" xml:space="preserve">
-          <source>Show icon on system tray area</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">Afficher l’icône sur la zone du plateau système</target>
-        </trans-unit>
-        <trans-unit id="Settings.Off" translate="yes" xml:space="preserve">
-          <source>Off</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Désactivé</target>
-        </trans-unit>
-        <trans-unit id="Settings.On" translate="yes" xml:space="preserve">
-          <source>On</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Activé</target>
+          <target state="translated">Apparence</target>
         </trans-unit>
         <trans-unit id="Settings.AppTheme" translate="yes" xml:space="preserve">
           <source>App Theme</source>
-          <target state="new">App Theme</target>
+          <target state="translated">Thème de l'application</target>
+        </trans-unit>
+        <trans-unit id="Settings.Behavior" translate="yes" xml:space="preserve">
+          <source>Behavior</source>
+          <target state="translated">Comportement</target>
+        </trans-unit>
+        <trans-unit id="Settings.DefaultFlyout" translate="yes" xml:space="preserve">
+          <source>Default Flyout</source>
+          <target state="translated">Menu volant par défaut</target>
+        </trans-unit>
+        <trans-unit id="Settings.DefaultFlyoutDescription" translate="yes" xml:space="preserve">
+          <source>Select the default flyout</source>
+          <target state="translated">Sélectionner le menu volant par défaut</target>
+        </trans-unit>
+        <trans-unit id="Settings.DefaultFlyoutWarningMessage" translate="yes" xml:space="preserve">
+          <source>Choosing the Windows Default Flyout as default won't close this app. This app will still keep running in the background. Please exit this app safely to improve performance.</source>
+          <target state="translated">Choisir le menu volant par défaut Windows comme menu par défaut ne fermera pas cette application. Cette application continuera à fonctionner en arrière-plan. Veuillez quitter cette application en toute sécurité pour améliorer les performances.</target>
+        </trans-unit>
+        <trans-unit id="Settings.Disabled" translate="yes" xml:space="preserve">
+          <source>Disabled</source>
+          <target state="translated">Désactivé</target>
+        </trans-unit>
+        <trans-unit id="Settings.Enabled" translate="yes" xml:space="preserve">
+          <source>Enabled</source>
+          <target state="translated">Activé</target>
+        </trans-unit>
+        <trans-unit id="Settings.EnableModule.Airplane" translate="yes" xml:space="preserve">
+          <source>Enable Airplane mode Flyout</source>
+          <target state="translated">Activer le menu volant du Mode Avion</target>
+        </trans-unit>
+        <trans-unit id="Settings.EnableModule.Audio" translate="yes" xml:space="preserve">
+          <source>Enable Audio Flyout</source>
+          <target state="translated">Activer le menu volant de l'Audio</target>
+        </trans-unit>
+        <trans-unit id="Settings.EnableModule.Brightness" translate="yes" xml:space="preserve">
+          <source>Enable Brightness Flyout</source>
+          <target state="translated">Activer le menu volant de la Luminosité</target>
+        </trans-unit>
+        <trans-unit id="Settings.EnableModule.LockKeys" translate="yes" xml:space="preserve">
+          <source>Enable Lock keys Flyout</source>
+          <target state="translated">Activer le menu volant des Touches de verrouillage</target>
+        </trans-unit>
+        <trans-unit id="Settings.FlyoutBackgroundOpacity" translate="yes" xml:space="preserve">
+          <source>Flyout background opacity</source>
+          <target state="translated">Opacité d’arrière-plan du menu volant</target>
+        </trans-unit>
+        <trans-unit id="Settings.FlyoutDefaultPosition" translate="yes" xml:space="preserve">
+          <source>Flyout default position</source>
+          <target state="translated">Position par défaut du menu volant (pour le bouton Aligner)</target>
+        </trans-unit>
+        <trans-unit id="Settings.FlyoutDefaultPositionDescription" translate="yes" xml:space="preserve">
+          <source>Type the position in 'X,Y' format (for e.g. 50,60)</source>
+          <target state="translated">Entrez la position au format 'X,Y' (par exemple 50,60)</target>
+        </trans-unit>
+        <trans-unit id="Settings.FlyoutTheme" translate="yes" xml:space="preserve">
+          <source>Flyout theme</source>
+          <target state="translated">Thème du menu volant</target>
+        </trans-unit>
+        <trans-unit id="Settings.FlyoutTimeout" translate="yes" xml:space="preserve">
+          <source>Flyout timeout (ms)</source>
+          <target state="translated">Temps d'affichage du menu volant (ms)</target>
+        </trans-unit>
+        <trans-unit id="Settings.FlyoutTopBar" translate="yes" xml:space="preserve">
+          <source>Flyout TopBar</source>
+          <target state="translated">Barre supérieure du menu volant</target>
+        </trans-unit>
+        <trans-unit id="Settings.Language" translate="yes" xml:space="preserve">
+          <source>Language</source>
+          <target state="translated">Langue</target>
+        </trans-unit>
+        <trans-unit id="Settings.LanguageDescription" translate="yes" xml:space="preserve">
+          <source>Restart required to apply language change properly</source>
+          <target state="translated">Redémarrage de l’application nécessaire pour changer la langue correctement</target>
+        </trans-unit>
+        <trans-unit id="Settings.Left" translate="yes" xml:space="preserve">
+          <source>Left</source>
+          <target state="translated">Gauche</target>
+        </trans-unit>
+        <trans-unit id="Settings.Modules" translate="yes" xml:space="preserve">
+          <source>Flyout Modules</source>
+          <target state="translated">Modules de menus volants</target>
+        </trans-unit>
+        <trans-unit id="Settings.Modules.Airplane" translate="yes" xml:space="preserve">
+          <source>Airplane mode</source>
+          <target state="translated">Mode Avion</target>
+        </trans-unit>
+        <trans-unit id="Settings.Modules.Audio" translate="yes" xml:space="preserve">
+          <source>Audio</source>
+          <target state="translated">Audio</target>
+        </trans-unit>
+        <trans-unit id="Settings.Modules.Audio.Media" translate="yes" xml:space="preserve">
+          <source>Media</source>
+          <target state="translated">Media</target>
+        </trans-unit>
+        <trans-unit id="Settings.Modules.Audio.Volume" translate="yes" xml:space="preserve">
+          <source>Volume</source>
+          <target state="translated">Volume</target>
+        </trans-unit>
+        <trans-unit id="Settings.Modules.Brightness" translate="yes" xml:space="preserve">
+          <source>Brightness</source>
+          <target state="translated">Luminosité</target>
+        </trans-unit>
+        <trans-unit id="Settings.Modules.LockKeys" translate="yes" xml:space="preserve">
+          <source>Lock keys</source>
+          <target state="translated">Touches de verrouillage</target>
+        </trans-unit>
+        <trans-unit id="Settings.Off" translate="yes" xml:space="preserve">
+          <source>Off</source>
+          <target state="translated">Désactivé</target>
+        </trans-unit>
+        <trans-unit id="Settings.On" translate="yes" xml:space="preserve">
+          <source>On</source>
+          <target state="translated">Activé</target>
+        </trans-unit>
+        <trans-unit id="Settings.Reset" translate="yes" xml:space="preserve">
+          <source>Reset</source>
+          <target state="translated">Réinitialiser</target>
+        </trans-unit>
+        <trans-unit id="Settings.ResetToDefaults" translate="yes" xml:space="preserve">
+          <source>Reset all settings to defaults</source>
+          <target state="translated">Réinitialiser tous les paramètres aux valeurs par défaut</target>
+        </trans-unit>
+        <trans-unit id="Settings.Right" translate="yes" xml:space="preserve">
+          <source>Right</source>
+          <target state="translated">Droite</target>
+        </trans-unit>
+        <trans-unit id="Settings.RunAtStartup" translate="yes" xml:space="preserve">
+          <source>Run at startup</source>
+          <target state="translated">Lancer au démarrage</target>
+        </trans-unit>
+        <trans-unit id="Settings.SystemDefault" translate="yes" xml:space="preserve">
+          <source>System default</source>
+          <target state="translated">Par défaut du système</target>
+        </trans-unit>
+        <trans-unit id="Settings.TopBarVisibility" translate="yes" xml:space="preserve">
+          <source>TopBar visibility</source>
+          <target state="translated">Visibilité de la barre supérieure</target>
+        </trans-unit>
+        <trans-unit id="Settings.TrayIconEnabled" translate="yes" xml:space="preserve">
+          <source>Show icon on system tray area</source>
+          <target state="translated">Afficher l'icône dans la zone de notification</target>
         </trans-unit>
         <trans-unit id="Settings.UseColoredTrayIcon" translate="yes" xml:space="preserve">
           <source>Use colored tray icon</source>
-          <target state="new">Use colored tray icon</target>
+          <target state="translated">Utiliser une icone de notification colorée</target>
+        </trans-unit>
+        <trans-unit id="SettingsItem" translate="yes" xml:space="preserve">
+          <source>Settings</source>
+          <target state="translated">Paramètres</target>
+        </trans-unit>
+        <trans-unit id="SettingsItemDescription" translate="yes" xml:space="preserve">
+          <source>Open settings window</source>
+          <target state="translated">Ouvrir la fenêtre des paramètres</target>
+        </trans-unit>
+        <trans-unit id="UnpinTopBar" translate="yes" xml:space="preserve">
+          <source>Unpin TopBar</source>
+          <target state="translated">Désépingler la barre supérieure</target>
         </trans-unit>
         <trans-unit id="NgsSettings_Reset" translate="yes" xml:space="preserve">
           <source>ngs.Settings_Reset}</source>
           <target state="new">ngs.Settings_Reset}</target>
-        </trans-unit>
-        <trans-unit id="Settings.Reset" translate="yes" xml:space="preserve">
-          <source>Reset</source>
-          <target state="new">Reset</target>
-        </trans-unit>
-        <trans-unit id="Settings.ResetToDefaults" translate="yes" xml:space="preserve">
-          <source>Reset all settings to defaults</source>
-          <target state="new">Reset all settings to defaults</target>
         </trans-unit>
       </group>
     </body>

--- a/ModernFlyouts/Properties/Strings.fr.resx
+++ b/ModernFlyouts/Properties/Strings.fr.resx
@@ -15,6 +15,30 @@
   <data name="About" xml:space="preserve">
     <value>À propos</value>
   </data>
+  <data name="About.AppDescription" xml:space="preserve">
+    <value>Cette application est conçue pour être un remplacement moderne en Fluent Design pour les anciens menus volants de type Metro présents dans Windows depuis Windows 8.</value>
+  </data>
+  <data name="About.Contributors" xml:space="preserve">
+    <value>Contributeurs</value>
+  </data>
+  <data name="About.Dependencies" xml:space="preserve">
+    <value>Dépendances</value>
+  </data>
+  <data name="About.FileABug" xml:space="preserve">
+    <value>Si vous trouvez des bogues, veuillez ouvrir un nouveau ticket dans le dépôt GitHub.</value>
+  </data>
+  <data name="About.GitHub" xml:space="preserve">
+    <value>Dépôt GitHub</value>
+  </data>
+  <data name="About.OpenNewIssue" xml:space="preserve">
+    <value>Ouvrir un nouveau ticket</value>
+  </data>
+  <data name="About.RateAndReview" xml:space="preserve">
+    <value>Notez et passez en revue sur le Microsoft Store</value>
+  </data>
+  <data name="About.Version" xml:space="preserve">
+    <value>Version : </value>
+  </data>
   <data name="AirplaneMode.NotAvailable" xml:space="preserve">
     <value>Le Mode Avion n’est pas disponible :(</value>
   </data>
@@ -27,11 +51,56 @@
   <data name="Align" xml:space="preserve">
     <value>Aligner sur la position par défaut</value>
   </data>
+  <data name="AudioFlyoutHelper.MaxVerticalSessionControlsCount" xml:space="preserve">
+    <value>Nombre de sessions à afficher</value>
+  </data>
   <data name="AudioFlyoutHelper.NoDevices" xml:space="preserve">
     <value>Aucun périphérique audio connecté</value>
   </data>
+  <data name="AudioFlyoutHelper.SessionsPanelOrientation" xml:space="preserve">
+    <value>Orientation du panneau des sessions médias</value>
+  </data>
+  <data name="AudioFlyoutHelper.ShowGSMTCInVolumeFlyout" xml:space="preserve">
+    <value>Afficher les contrôles de transport global des médias systèmes (GSMTC) alias les contrôles médias, dans le menu volant Volume</value>
+  </data>
+  <data name="AudioFlyoutHelper.ShowVolumeControlInGSMTCFlyout" xml:space="preserve">
+    <value>Afficher le contrôle Volume dans le menu volant des contrôles de transport global des médias systèmes (GSMTC) alias le menu volant des médias</value>
+  </data>
+  <data name="AudioFlyoutHelper.ThumbnailAlignment" xml:space="preserve">
+    <value>Alignement de la miniature</value>
+  </data>
   <data name="Close" xml:space="preserve">
     <value>Fermer</value>
+  </data>
+  <data name="Enums.DefaultFlyout.ModernFlyouts" xml:space="preserve">
+    <value>ModernFlyouts</value>
+  </data>
+  <data name="Enums.DefaultFlyout.None" xml:space="preserve">
+    <value>Aucun</value>
+  </data>
+  <data name="Enums.DefaultFlyout.WindowsDefault" xml:space="preserve">
+    <value>Windows par défaut</value>
+  </data>
+  <data name="Enums.ElementTheme.Dark" xml:space="preserve">
+    <value>Sombre</value>
+  </data>
+  <data name="Enums.ElementTheme.Light" xml:space="preserve">
+    <value>Clair</value>
+  </data>
+  <data name="Enums.Orientation.Horizontal" xml:space="preserve">
+    <value>Horizontale</value>
+  </data>
+  <data name="Enums.Orientation.Vertical" xml:space="preserve">
+    <value>Verticale</value>
+  </data>
+  <data name="Enums.TopBarVisibility.AutoHide" xml:space="preserve">
+    <value>Masquer automatiquement</value>
+  </data>
+  <data name="Enums.TopBarVisibility.Collapsed" xml:space="preserve">
+    <value>Réduite</value>
+  </data>
+  <data name="Enums.TopBarVisibility.Visible" xml:space="preserve">
+    <value>Visible</value>
   </data>
   <data name="ExitItem" xml:space="preserve">
     <value>Quitter</value>
@@ -42,8 +111,14 @@
   <data name="GeneralSettings" xml:space="preserve">
     <value>Général</value>
   </data>
+  <data name="LockKeysFlyoutHelper.CapsLock" xml:space="preserve">
+    <value>Verr Maj</value>
+  </data>
+  <data name="LockKeysFlyoutHelper.Insert" xml:space="preserve">
+    <value>Insérer</value>
+  </data>
   <data name="LockKeysFlyoutHelper.InsertMode" xml:space="preserve">
-    <value>Mode insertion</value>
+    <value>Mode Insertion</value>
   </data>
   <data name="LockKeysFlyoutHelper.KeyIsOff" xml:space="preserve">
     <value>{0} est désactivé</value>
@@ -53,8 +128,17 @@
     <value>{0} est activé</value>
     <comment>E.g. Caps lock is on</comment>
   </data>
+  <data name="LockKeysFlyoutHelper.NumLock" xml:space="preserve">
+    <value>Verr Num</value>
+  </data>
   <data name="LockKeysFlyoutHelper.OvertypeMode" xml:space="preserve">
-    <value>Mode refrappe</value>
+    <value>Mode Refrappe</value>
+  </data>
+  <data name="LockKeysFlyoutHelper.ScrollLock" xml:space="preserve">
+    <value>Verr Défil</value>
+  </data>
+  <data name="LockKeysFlyoutHelper.SelectKeyDescription" xml:space="preserve">
+    <value>Selectionnez les touches dont vous voulez un menu volant</value>
   </data>
   <data name="PinTopBar" xml:space="preserve">
     <value>Épingler la barre supérieure</value>
@@ -72,10 +156,10 @@
     <comment>Error message shown when there is problem in converting an object into a string</comment>
   </data>
   <data name="RestoreDefaultItem" xml:space="preserve">
-    <value>Restaurer les paramètres par défaut</value>
+    <value>Restaurer l'ancien menu volant</value>
   </data>
   <data name="RestoreDefaultItemDescription" xml:space="preserve">
-    <value>Restaure le menu volant par défaut windows et quitte en toute sécurité cette application</value>
+    <value>Restaure le menu volant par défaut de Windows et quitte en toute sécurité cette application</value>
   </data>
   <data name="SessionControl.MoreControls" xml:space="preserve">
     <value>Autres contrôles</value>
@@ -116,6 +200,12 @@
   <data name="Settings.Additional" xml:space="preserve">
     <value>Additionnel</value>
   </data>
+  <data name="Settings.Appearance" xml:space="preserve">
+    <value>Apparence</value>
+  </data>
+  <data name="Settings.AppTheme" xml:space="preserve">
+    <value>Thème de l'application</value>
+  </data>
   <data name="Settings.Behavior" xml:space="preserve">
     <value>Comportement</value>
   </data>
@@ -134,6 +224,18 @@
   <data name="Settings.Enabled" xml:space="preserve">
     <value>Activé</value>
   </data>
+  <data name="Settings.EnableModule.Airplane" xml:space="preserve">
+    <value>Activer le menu volant du Mode Avion</value>
+  </data>
+  <data name="Settings.EnableModule.Audio" xml:space="preserve">
+    <value>Activer le menu volant de l'Audio</value>
+  </data>
+  <data name="Settings.EnableModule.Brightness" xml:space="preserve">
+    <value>Activer le menu volant de la Luminosité</value>
+  </data>
+  <data name="Settings.EnableModule.LockKeys" xml:space="preserve">
+    <value>Activer le menu volant des Touches de verrouillage</value>
+  </data>
   <data name="Settings.FlyoutBackgroundOpacity" xml:space="preserve">
     <value>Opacité d’arrière-plan du menu volant</value>
   </data>
@@ -143,26 +245,74 @@
   <data name="Settings.FlyoutDefaultPositionDescription" xml:space="preserve">
     <value>Entrez la position au format 'X,Y' (par exemple 50,60)</value>
   </data>
+  <data name="Settings.FlyoutTheme" xml:space="preserve">
+    <value>Thème du menu volant</value>
+  </data>
+  <data name="Settings.FlyoutTimeout" xml:space="preserve">
+    <value>Temps d'affichage du menu volant (ms)</value>
+  </data>
   <data name="Settings.FlyoutTopBar" xml:space="preserve">
     <value>Barre supérieure du menu volant</value>
   </data>
+  <data name="Settings.Language" xml:space="preserve">
+    <value>Langue</value>
+  </data>
+  <data name="Settings.LanguageDescription" xml:space="preserve">
+    <value>Redémarrage de l’application nécessaire pour changer la langue correctement</value>
+  </data>
+  <data name="Settings.Left" xml:space="preserve">
+    <value>Gauche</value>
+  </data>
   <data name="Settings.Modules" xml:space="preserve">
-    <value>Modules</value>
+    <value>Modules de menus volants</value>
   </data>
   <data name="Settings.Modules.Airplane" xml:space="preserve">
-    <value>Module menu volant Mode Avion</value>
+    <value>Mode Avion</value>
   </data>
   <data name="Settings.Modules.Audio" xml:space="preserve">
-    <value>Module menu volant Audio</value>
+    <value>Audio</value>
+  </data>
+  <data name="Settings.Modules.Audio.Media" xml:space="preserve">
+    <value>Media</value>
+  </data>
+  <data name="Settings.Modules.Audio.Volume" xml:space="preserve">
+    <value>Volume</value>
   </data>
   <data name="Settings.Modules.Brightness" xml:space="preserve">
-    <value>Module menu volant Luminosité</value>
+    <value>Luminosité</value>
   </data>
   <data name="Settings.Modules.LockKeys" xml:space="preserve">
-    <value>Module menu volant Touches de verrouillage</value>
+    <value>Touches de verrouillage</value>
+  </data>
+  <data name="Settings.Off" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="Settings.On" xml:space="preserve">
+    <value>Activé</value>
+  </data>
+  <data name="Settings.Reset" xml:space="preserve">
+    <value>Réinitialiser</value>
+  </data>
+  <data name="Settings.ResetToDefaults" xml:space="preserve">
+    <value>Réinitialiser tous les paramètres aux valeurs par défaut</value>
+  </data>
+  <data name="Settings.Right" xml:space="preserve">
+    <value>Droite</value>
   </data>
   <data name="Settings.RunAtStartup" xml:space="preserve">
     <value>Lancer au démarrage</value>
+  </data>
+  <data name="Settings.SystemDefault" xml:space="preserve">
+    <value>Par défaut du système</value>
+  </data>
+  <data name="Settings.TopBarVisibility" xml:space="preserve">
+    <value>Visibilité de la barre supérieure</value>
+  </data>
+  <data name="Settings.TrayIconEnabled" xml:space="preserve">
+    <value>Afficher l'icône dans la zone de notification</value>
+  </data>
+  <data name="Settings.UseColoredTrayIcon" xml:space="preserve">
+    <value>Utiliser une icone de notification colorée</value>
   </data>
   <data name="SettingsItem" xml:space="preserve">
     <value>Paramètres</value>
@@ -172,143 +322,5 @@
   </data>
   <data name="UnpinTopBar" xml:space="preserve">
     <value>Désépingler la barre supérieure</value>
-  </data>
-  <data name="Enums.DefaultFlyout.ModernFlyouts" xml:space="preserve">
-    <value>ModernFlyouts</value>
-  </data>
-  <data name="Enums.DefaultFlyout.None" xml:space="preserve">
-    <value>Aucun</value>
-  </data>
-  <data name="Enums.DefaultFlyout.WindowsDefault" xml:space="preserve">
-    <value>Windows par défaut</value>
-  </data>
-  <data name="Enums.Orientation.Horizontal" xml:space="preserve">
-    <value>Horizontalement</value>
-  </data>
-  <data name="Enums.Orientation.Vertical" xml:space="preserve">
-    <value>Verticale</value>
-  </data>
-  <data name="About.AppDescription" xml:space="preserve">
-    <value>Cette application est conçue pour être un remplacement moderne fluent design pour les anciens flyouts sur le thème du métro présents dans Windows depuis Windows 8.</value>
-  </data>
-  <data name="About.Contributors" xml:space="preserve">
-    <value>Collaborateurs</value>
-  </data>
-  <data name="About.GitHub" xml:space="preserve">
-    <value>Dépôt GitHub</value>
-  </data>
-  <data name="About.OpenNewIssue" xml:space="preserve">
-    <value>Ouvrir un nouveau numéro</value>
-  </data>
-  <data name="About.RateAndReview" xml:space="preserve">
-    <value>Taux et révision sur Microsoft Store</value>
-  </data>
-  <data name="About.Version" xml:space="preserve">
-    <value>Version: </value>
-  </data>
-  <data name="Settings.Language" xml:space="preserve">
-    <value>Langue</value>
-  </data>
-  <data name="Settings.LanguageDescription" xml:space="preserve">
-    <value>S’il vous plaît redémarrer l’application pour changer la langue correctement</value>
-  </data>
-  <data name="Settings.SystemDefault" xml:space="preserve">
-    <value>Valeur système par défaut</value>
-  </data>
-  <data name="About.Dependencies" xml:space="preserve">
-    <value>Dépendances</value>
-  </data>
-  <data name="About.FileABug" xml:space="preserve">
-    <value>Si vous trouvez des bogues, ouvrez un nouveau problème dans le référentiel github.</value>
-  </data>
-  <data name="AudioFlyoutHelper.MaxVerticalSessionControlsCount" xml:space="preserve">
-    <value>Nombre de séances à afficher</value>
-  </data>
-  <data name="AudioFlyoutHelper.SessionsPanelOrientation" xml:space="preserve">
-    <value>Orientation du panel des sessions de médias</value>
-  </data>
-  <data name="AudioFlyoutHelper.ShowGSMTCInVolumeFlyout" xml:space="preserve">
-    <value>Afficher global system media transport controls (GSMTC) aka Media controls in Volume flyout</value>
-  </data>
-  <data name="AudioFlyoutHelper.ShowVolumeControlInGSMTCFlyout" xml:space="preserve">
-    <value>Afficher le contrôle du volume dans Global System Media Transport Controls (GSMTC) aka Media flyout</value>
-  </data>
-  <data name="AudioFlyoutHelper.ThumbnailAlignment" xml:space="preserve">
-    <value>Alignement des miniatures</value>
-  </data>
-  <data name="Enums.ElementTheme.Dark" xml:space="preserve">
-    <value>Sombre</value>
-  </data>
-  <data name="Enums.ElementTheme.Light" xml:space="preserve">
-    <value>Clair</value>
-  </data>
-  <data name="Enums.TopBarVisibility.AutoHide" xml:space="preserve">
-    <value>Masquer automatiquement</value>
-  </data>
-  <data name="Enums.TopBarVisibility.Collapsed" xml:space="preserve">
-    <value>Réduit</value>
-  </data>
-  <data name="Enums.TopBarVisibility.Visible" xml:space="preserve">
-    <value>Visible</value>
-  </data>
-  <data name="LockKeysFlyoutHelper.CapsLock" xml:space="preserve">
-    <value>Verr. maj</value>
-  </data>
-  <data name="LockKeysFlyoutHelper.Insert" xml:space="preserve">
-    <value>Insérer</value>
-  </data>
-  <data name="LockKeysFlyoutHelper.NumLock" xml:space="preserve">
-    <value>Verrouillage num</value>
-  </data>
-  <data name="LockKeysFlyoutHelper.ScrollLock" xml:space="preserve">
-    <value>Verrouillage de défilement</value>
-  </data>
-  <data name="LockKeysFlyoutHelper.SelectKeyDescription" xml:space="preserve">
-    <value>Sélectionnez les touches pour lesquelle vous souhaitez afficher le menu volant</value>
-  </data>
-  <data name="Settings.Appearance" xml:space="preserve">
-    <value>Apparence</value>
-  </data>
-  <data name="Settings.EnableModule.Airplane" xml:space="preserve">
-    <value>Activer le mode Flyout</value>
-  </data>
-  <data name="Settings.EnableModule.Audio" xml:space="preserve">
-    <value>Activer le vol d’envol audio</value>
-  </data>
-  <data name="Settings.EnableModule.Brightness" xml:space="preserve">
-    <value>Activer le flyout de luminosité</value>
-  </data>
-  <data name="Settings.EnableModule.LockKeys" xml:space="preserve">
-    <value>Activer les clés de verrouillage Flyout</value>
-  </data>
-  <data name="Settings.FlyoutTheme" xml:space="preserve">
-    <value>Thème Flyout</value>
-  </data>
-  <data name="Settings.FlyoutTimeout" xml:space="preserve">
-    <value>Délai d’expiration de vol d’arrêt (ms)</value>
-  </data>
-  <data name="Settings.Left" xml:space="preserve">
-    <value>Gauche</value>
-  </data>
-  <data name="Settings.Modules.Audio.Media" xml:space="preserve">
-    <value>Média</value>
-  </data>
-  <data name="Settings.Modules.Audio.Volume" xml:space="preserve">
-    <value>Année</value>
-  </data>
-  <data name="Settings.Right" xml:space="preserve">
-    <value>Droite</value>
-  </data>
-  <data name="Settings.TopBarVisibility" xml:space="preserve">
-    <value>Visibilité TopBar</value>
-  </data>
-  <data name="Settings.TrayIconEnabled" xml:space="preserve">
-    <value>Afficher l’icône sur la zone du plateau système</value>
-  </data>
-  <data name="Settings.Off" xml:space="preserve">
-    <value>Désactivé</value>
-  </data>
-  <data name="Settings.On" xml:space="preserve">
-    <value>Activé</value>
   </data>
 </root>

--- a/ModernFlyouts/Properties/Strings.resx
+++ b/ModernFlyouts/Properties/Strings.resx
@@ -395,6 +395,12 @@
   <data name="Settings.On" xml:space="preserve">
     <value>On</value>
   </data>
+  <data name="Settings.Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="Settings.ResetToDefaults" xml:space="preserve">
+    <value>Reset all settings to defaults</value>
+  </data>
   <data name="Settings.Right" xml:space="preserve">
     <value>Right</value>
   </data>
@@ -424,11 +430,5 @@
   </data>
   <data name="NgsSettings_Reset" xml:space="preserve">
     <value>ngs.Settings_Reset}</value>
-  </data>
-  <data name="Settings.Reset" xml:space="preserve">
-    <value>Reset</value>
-  </data>
-  <data name="Settings.ResetToDefaults" xml:space="preserve">
-    <value>Reset all settings to defaults</value>
   </data>
 </root>


### PR DESCRIPTION
And it's back another time.

@Samuel12321, I think I understand why translations are being reverted.
When building on Visual Studio, it builds the .resx files from the .xlf, so I think changes must be done to the .xlf files

For what I did : I translated the strings properly on the .resx, then deleted and recreated the .xlf from the Multilingual App Toolkit extension (it automatically imports from the localized .resx file), and manually validated review-requested strings (when source and target are the same) on the standalone editor, and I finally have something clean

So if there are translations added and if you want to apply them from one file to another, make sure you don't build the solution (and at least the ModernFlyouts C# project) before you have done the changes 🙂 